### PR TITLE
feat: add start menu

### DIFF
--- a/src/components/Desktop/Desktop.tsx
+++ b/src/components/Desktop/Desktop.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import AppIcon from "../AppIcon/AppIcon";
 import classes from "./Desktop.module.css";
 import Taskbar from "../Taskbar/Taskbar";
@@ -13,6 +13,7 @@ import TechApplication from "../Applications/TechApplication/TechApplication";
 import ContactApplication from "../Applications/ContactApplication/ContactApplication";
 import CreditsApplication from "../Applications/CreditsApplication/CreditsApplication";
 import MobileWarning from "../MobileWarning/MobileWarning";
+import StartMenu from "../StartMenu/StartMenu";
 
 interface App {
   name: string;
@@ -109,6 +110,8 @@ const apps: App[] = [
 const Desktop = () => {
   const { incZIndex, getZIndex } = WindowStore();
 
+  const [ numberOfOpenedApps, setNumberOfOpenedApps ] = useState(0);
+
   const [appStates, setAppStates] = useState<AppStates>(() =>
     apps.reduce((acc, app) => {
       acc[app.name] = { isOpen: false, isHidden: false };
@@ -135,9 +138,15 @@ const Desktop = () => {
     }));
   };
 
+  // Update the number of opened apps to display the start menu in the correct position
+  useEffect(() => {
+    setNumberOfOpenedApps(Object.values(appStates).filter(app => app.isOpen).length);
+  }, [setNumberOfOpenedApps, appStates])
+
   return (
     <>
       <MobileWarning />
+      <StartMenu numberOfOpenedApps={numberOfOpenedApps} />
       <div className={classes.desktop}>
         {/* Desktop Icons */}
         {apps.map(({ name, icon, title, position }) => (

--- a/src/components/Desktop/Desktop.tsx
+++ b/src/components/Desktop/Desktop.tsx
@@ -13,9 +13,8 @@ import TechApplication from "../Applications/TechApplication/TechApplication";
 import ContactApplication from "../Applications/ContactApplication/ContactApplication";
 import CreditsApplication from "../Applications/CreditsApplication/CreditsApplication";
 import MobileWarning from "../MobileWarning/MobileWarning";
-import StartMenu from "../StartMenu/StartMenu";
 
-interface App {
+export interface App {
   name: string;
   icon: string;
   title: string;
@@ -199,9 +198,11 @@ const Desktop = () => {
         ))}
       </div>
       <Taskbar
+        appList={apps}
         numberOfOpenedApps={numberOfOpenedApps}
         isStartMenuOpen={isStartMenuOpen}
         handleToggleStartMenu={toggleStartMenu}
+        handleOpenApp={handleOpenApp}
       >
         {/* Taskbar Icons */}
         {apps.map(({ name, icon, title }) => (

--- a/src/components/Desktop/Desktop.tsx
+++ b/src/components/Desktop/Desktop.tsx
@@ -110,7 +110,8 @@ const apps: App[] = [
 const Desktop = () => {
   const { incZIndex, getZIndex } = WindowStore();
 
-  const [ numberOfOpenedApps, setNumberOfOpenedApps ] = useState(0);
+  const [numberOfOpenedApps, setNumberOfOpenedApps] = useState(0);
+  const [isStartMenuOpen, setIsStartMenuOpen] = useState(false);
 
   const [appStates, setAppStates] = useState<AppStates>(() =>
     apps.reduce((acc, app) => {
@@ -138,15 +139,20 @@ const Desktop = () => {
     }));
   };
 
+  const toggleStartMenu = () => {
+    setIsStartMenuOpen(!isStartMenuOpen);
+  };
+
   // Update the number of opened apps to display the start menu in the correct position
   useEffect(() => {
-    setNumberOfOpenedApps(Object.values(appStates).filter(app => app.isOpen).length);
-  }, [setNumberOfOpenedApps, appStates])
+    setNumberOfOpenedApps(
+      Object.values(appStates).filter((app) => app.isOpen).length
+    );
+  }, [setNumberOfOpenedApps, appStates]);
 
   return (
     <>
       <MobileWarning />
-      <StartMenu numberOfOpenedApps={numberOfOpenedApps} />
       <div className={classes.desktop}>
         {/* Desktop Icons */}
         {apps.map(({ name, icon, title, position }) => (
@@ -192,7 +198,11 @@ const Desktop = () => {
           />
         ))}
       </div>
-      <Taskbar>
+      <Taskbar
+        numberOfOpenedApps={numberOfOpenedApps}
+        isStartMenuOpen={isStartMenuOpen}
+        handleToggleStartMenu={toggleStartMenu}
+      >
         {/* Taskbar Icons */}
         {apps.map(({ name, icon, title }) => (
           <TaskbarIcon

--- a/src/components/StartMenu/PinnedApplications.module.css
+++ b/src/components/StartMenu/PinnedApplications.module.css
@@ -1,5 +1,6 @@
 .pinnedApplicationsContainer {
-    margin: 30px 0;
+    margin: 8px 0;
+    padding: 16px;
 }
 
 .pinnedApplicationsGrid {

--- a/src/components/StartMenu/PinnedApplications.module.css
+++ b/src/components/StartMenu/PinnedApplications.module.css
@@ -1,0 +1,36 @@
+.pinnedApplicationsContainer {
+    margin: 30px 0;
+}
+
+.pinnedApplicationsGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+    gap: 10px;
+    padding: 10px;
+    justify-content: center;
+    place-items: center;
+    align-items: center;
+    justify-content: center;
+}
+
+.pinnedApp {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    padding: 10px;
+    border-radius: 10px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.pinnedApp:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.pinnedText {
+    font-size: 14px;
+    margin-left: 16px;
+}

--- a/src/components/StartMenu/PinnedApplications.tsx
+++ b/src/components/StartMenu/PinnedApplications.tsx
@@ -1,0 +1,30 @@
+import classes from "./PinnedApplications.module.css";
+import { App } from "../Desktop/Desktop";
+
+const PinnedApplications = ({
+  appList,
+  handleOpenApp,
+}: {
+  appList: App[];
+  handleOpenApp: (appName: string) => void;
+}) => {
+  return (
+    <div className={classes.pinnedApplicationsContainer}>
+      <h3 className={classes.pinnedText}>Pinned</h3>
+      <div className={classes.pinnedApplicationsGrid}>
+        {appList.map(({ name, icon, title }) => (
+          <div
+            key={name}
+            className={classes.pinnedApp}
+            onClick={() => handleOpenApp(name)}
+          >
+            <img src={icon} alt={title} />
+            <span>{title}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PinnedApplications;

--- a/src/components/StartMenu/SearchBar.module.css
+++ b/src/components/StartMenu/SearchBar.module.css
@@ -18,4 +18,9 @@
 
 .searchBar {
   flex-grow: 2;
+  outline: none;
+}
+
+.searchBar:focus {
+  outline: none;
 }

--- a/src/components/StartMenu/SearchBar.module.css
+++ b/src/components/StartMenu/SearchBar.module.css
@@ -1,0 +1,21 @@
+.searchWrapper {
+  background-color: white;
+  gap: 12px;
+  width: 100%;
+  margin: 12px 0;
+  border-radius: 12px;
+  padding: 2px 8px;
+  color: black;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.searchIcon {
+  width: 18px;
+  height: 18px;
+}
+
+.searchBar {
+  flex-grow: 2;
+}

--- a/src/components/StartMenu/SearchBar.tsx
+++ b/src/components/StartMenu/SearchBar.tsx
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import classes from "./SearchBar.module.css";
+import { IconSearch } from "@tabler/icons-react";
+
+const SearchBar = () => {
+  const [searchValue, setSearchValue] = useState<string>("");
+
+  const updateInputValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(e.target.value);
+  };
+
+  return (
+    <div className={classes.searchWrapper}>
+      <IconSearch className={classes.searchIcon} />
+      <input
+        className={classes.searchBar}
+        type="text"
+        value={searchValue}
+        placeholder="Search apps, settings, documents..."
+        onChange={updateInputValue} // Directly pass the function
+      />
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/src/components/StartMenu/SearchBar.tsx
+++ b/src/components/StartMenu/SearchBar.tsx
@@ -17,7 +17,7 @@ const SearchBar = () => {
         type="text"
         value={searchValue}
         placeholder="Search apps, settings, documents..."
-        onChange={updateInputValue} // Directly pass the function
+        onChange={updateInputValue}
       />
     </div>
   );

--- a/src/components/StartMenu/StartMenu.module.css
+++ b/src/components/StartMenu/StartMenu.module.css
@@ -12,21 +12,24 @@
   z-index: 2147483647;
   background-color: rgba(69, 69, 69, 0.942);
   width: 500px;
-  padding: 16px;
   border-radius: 8px;
   color: #fff;
 }
 
 .raccoonOsTitle {
   font-family: monospace;
+  margin-bottom: 16px;
+  display: block;
 }
 
 .shutdownSection {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   justify-items: center;
   align-items: center;
   padding: 10px 0 0 0;
+  background-color: rgba(0, 0, 0, 0.293);
+  padding: 16px;
 }
 
 .shutdownButton {

--- a/src/components/StartMenu/StartMenu.module.css
+++ b/src/components/StartMenu/StartMenu.module.css
@@ -1,0 +1,5 @@
+.startMenu {
+    position: fixed;
+    bottom: 64px;
+    z-index: 99999999;
+}

--- a/src/components/StartMenu/StartMenu.module.css
+++ b/src/components/StartMenu/StartMenu.module.css
@@ -1,3 +1,11 @@
+.startMenuBackground {
+  z-index: 99999998;
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+  top: 0;
+}
+
 .startMenu {
   position: fixed;
   bottom: 62px;

--- a/src/components/StartMenu/StartMenu.module.css
+++ b/src/components/StartMenu/StartMenu.module.css
@@ -1,5 +1,5 @@
 .startMenuBackground {
-  z-index: 99999998;
+  z-index: 2147483646;
   position: fixed;
   width: 100vw;
   height: 100vh;
@@ -9,7 +9,7 @@
 .startMenu {
   position: fixed;
   bottom: 62px;
-  z-index: 99999999;
+  z-index: 2147483647;
   background-color: rgba(69, 69, 69, 0.942);
   width: 500px;
   padding: 16px;

--- a/src/components/StartMenu/StartMenu.module.css
+++ b/src/components/StartMenu/StartMenu.module.css
@@ -1,5 +1,36 @@
 .startMenu {
-    position: fixed;
-    bottom: 64px;
-    z-index: 99999999;
+  position: fixed;
+  bottom: 62px;
+  z-index: 99999999;
+  background-color: rgba(69, 69, 69, 0.942);
+  width: 500px;
+  padding: 16px;
+  border-radius: 8px;
+  color: #fff;
+}
+
+.raccoonOsTitle {
+  font-family: monospace;
+}
+
+.shutdownSection {
+  display: flex;
+  justify-content: space-between;
+  justify-items: center;
+  align-items: center;
+  padding: 10px 0 0 0;
+}
+
+.shutdownButton {
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 4px;
+}
+
+.shutdownButton:hover {
+  background-color: rgba(0, 0, 0, 0.314);
+}
+
+.shutdownButton:active {
+  background-color: rgba(0, 0, 0, 0.514);
 }

--- a/src/components/StartMenu/StartMenu.tsx
+++ b/src/components/StartMenu/StartMenu.tsx
@@ -1,13 +1,24 @@
 import classes from "./StartMenu.module.css";
 
-const StartMenu = ({ numberOfOpenedApps }: { numberOfOpenedApps: number }) => {
+const StartMenu = ({
+  numberOfOpenedApps,
+  isOpen,
+}: {
+  numberOfOpenedApps: number;
+  isOpen: boolean;
+}) => {
   // Just eyeballed this but it works by calculating the left position of the start menu based on the number of opened apps
   const leftPosition = `calc((${numberOfOpenedApps} * -20px - ${numberOfOpenedApps}px * 5) + (50% - 45px))`;
 
   return (
-    <div style={{ left: leftPosition }} className={classes.startMenu}>
-      StartMenu
-    </div>
+    isOpen && (
+      <div
+        style={{ left: leftPosition }}
+        className={classes.startMenu}
+      >
+        StartMenu
+      </div>
+    )
   );
 };
 

--- a/src/components/StartMenu/StartMenu.tsx
+++ b/src/components/StartMenu/StartMenu.tsx
@@ -18,7 +18,7 @@ const StartMenu = ({
   handleToggleStartMenu: () => void;
 }) => {
   // Just eyeballed this but it works by calculating the left position of the start menu based on the number of opened apps
-  const leftPosition = `calc((${numberOfOpenedApps} * -20px - ${numberOfOpenedApps}px * 5) + (50% - 41px))`;
+  const leftPosition = `calc((${numberOfOpenedApps} * -20px - ${numberOfOpenedApps}px * 5) + (50% - 250px))`;
 
   const handleOpenAppHidingStartMenu = (appName: string) => {
     handleToggleStartMenu();

--- a/src/components/StartMenu/StartMenu.tsx
+++ b/src/components/StartMenu/StartMenu.tsx
@@ -22,8 +22,8 @@ const StartMenu = ({
 
   return (
     isOpen && (
-      /* This background enables closing the start menu when clicking outside of it */
       <>
+        {/* This is the background that will close the start menu when clicked */}
         <div
           className={classes.startMenuBackground}
           onClick={handleToggleStartMenu}

--- a/src/components/StartMenu/StartMenu.tsx
+++ b/src/components/StartMenu/StartMenu.tsx
@@ -1,0 +1,14 @@
+import classes from "./StartMenu.module.css";
+
+const StartMenu = ({ numberOfOpenedApps }: { numberOfOpenedApps: number }) => {
+  // Just eyeballed this but it works by calculating the left position of the start menu based on the number of opened apps
+  const leftPosition = `calc((${numberOfOpenedApps} * -20px - ${numberOfOpenedApps}px * 5) + (50% - 45px))`;
+
+  return (
+    <div style={{ left: leftPosition }} className={classes.startMenu}>
+      StartMenu
+    </div>
+  );
+};
+
+export default StartMenu;

--- a/src/components/StartMenu/StartMenu.tsx
+++ b/src/components/StartMenu/StartMenu.tsx
@@ -1,5 +1,5 @@
-import { IconPower } from "@tabler/icons-react";
 import classes from "./StartMenu.module.css";
+import { IconPower } from "@tabler/icons-react";
 import SearchBar from "./SearchBar";
 import PinnedApplications from "./PinnedApplications";
 import { App } from "../Desktop/Desktop";
@@ -9,28 +9,37 @@ const StartMenu = ({
   numberOfOpenedApps,
   isOpen,
   handleOpenApp,
+  handleToggleStartMenu,
 }: {
   appList: App[];
   numberOfOpenedApps: number;
   isOpen: boolean;
   handleOpenApp: (appName: string) => void;
+  handleToggleStartMenu: () => void;
 }) => {
   // Just eyeballed this but it works by calculating the left position of the start menu based on the number of opened apps
   const leftPosition = `calc((${numberOfOpenedApps} * -20px - ${numberOfOpenedApps}px * 5) + (50% - 41px))`;
 
   return (
     isOpen && (
-      <div style={{ left: leftPosition }} className={classes.startMenu}>
-        <span className={classes.raccoonOsTitle}>raccoonOS v1.0</span>
-        <SearchBar />
-        <PinnedApplications appList={appList} handleOpenApp={handleOpenApp} />
-        <div className={classes.shutdownSection}>
-          <div>RaccoonDude</div>
-          <div className={classes.shutdownButton}>
-            <IconPower />
+      /* This background enables closing the start menu when clicking outside of it */
+      <>
+        <div
+          className={classes.startMenuBackground}
+          onClick={handleToggleStartMenu}
+        />
+        <div style={{ left: leftPosition }} className={classes.startMenu}>
+          <span className={classes.raccoonOsTitle}>raccoonOS v1.0</span>
+          <SearchBar />
+          <PinnedApplications appList={appList} handleOpenApp={handleOpenApp} />
+          <div className={classes.shutdownSection}>
+            <div>RaccoonDude</div>
+            <div className={classes.shutdownButton}>
+              <IconPower />
+            </div>
           </div>
         </div>
-      </div>
+      </>
     )
   );
 };

--- a/src/components/StartMenu/StartMenu.tsx
+++ b/src/components/StartMenu/StartMenu.tsx
@@ -34,11 +34,15 @@ const StartMenu = ({
           onClick={handleToggleStartMenu}
         />
         <div style={{ left: leftPosition }} className={classes.startMenu}>
-          <span className={classes.raccoonOsTitle}>raccoonOS v1.0</span>
-          <SearchBar />
-          <PinnedApplications appList={appList} handleOpenApp={handleOpenAppHidingStartMenu} />
+          <div style={{ padding: 16 }}>
+            <span className={classes.raccoonOsTitle}>raccoonOS v1.0</span>
+            <SearchBar />
+          </div>
+          <PinnedApplications
+            appList={appList}
+            handleOpenApp={handleOpenAppHidingStartMenu}
+          />
           <div className={classes.shutdownSection}>
-            <div>RaccoonDude</div>
             <div className={classes.shutdownButton}>
               <IconPower />
             </div>

--- a/src/components/StartMenu/StartMenu.tsx
+++ b/src/components/StartMenu/StartMenu.tsx
@@ -1,22 +1,35 @@
+import { IconPower } from "@tabler/icons-react";
 import classes from "./StartMenu.module.css";
+import SearchBar from "./SearchBar";
+import PinnedApplications from "./PinnedApplications";
+import { App } from "../Desktop/Desktop";
 
 const StartMenu = ({
+  appList,
   numberOfOpenedApps,
   isOpen,
+  handleOpenApp,
 }: {
+  appList: App[];
   numberOfOpenedApps: number;
   isOpen: boolean;
+  handleOpenApp: (appName: string) => void;
 }) => {
   // Just eyeballed this but it works by calculating the left position of the start menu based on the number of opened apps
-  const leftPosition = `calc((${numberOfOpenedApps} * -20px - ${numberOfOpenedApps}px * 5) + (50% - 45px))`;
+  const leftPosition = `calc((${numberOfOpenedApps} * -20px - ${numberOfOpenedApps}px * 5) + (50% - 41px))`;
 
   return (
     isOpen && (
-      <div
-        style={{ left: leftPosition }}
-        className={classes.startMenu}
-      >
-        StartMenu
+      <div style={{ left: leftPosition }} className={classes.startMenu}>
+        <span className={classes.raccoonOsTitle}>raccoonOS v1.0</span>
+        <SearchBar />
+        <PinnedApplications appList={appList} handleOpenApp={handleOpenApp} />
+        <div className={classes.shutdownSection}>
+          <div>RaccoonDude</div>
+          <div className={classes.shutdownButton}>
+            <IconPower />
+          </div>
+        </div>
       </div>
     )
   );

--- a/src/components/StartMenu/StartMenu.tsx
+++ b/src/components/StartMenu/StartMenu.tsx
@@ -20,6 +20,11 @@ const StartMenu = ({
   // Just eyeballed this but it works by calculating the left position of the start menu based on the number of opened apps
   const leftPosition = `calc((${numberOfOpenedApps} * -20px - ${numberOfOpenedApps}px * 5) + (50% - 41px))`;
 
+  const handleOpenAppHidingStartMenu = (appName: string) => {
+    handleToggleStartMenu();
+    handleOpenApp(appName);
+  };
+
   return (
     isOpen && (
       <>
@@ -31,7 +36,7 @@ const StartMenu = ({
         <div style={{ left: leftPosition }} className={classes.startMenu}>
           <span className={classes.raccoonOsTitle}>raccoonOS v1.0</span>
           <SearchBar />
-          <PinnedApplications appList={appList} handleOpenApp={handleOpenApp} />
+          <PinnedApplications appList={appList} handleOpenApp={handleOpenAppHidingStartMenu} />
           <div className={classes.shutdownSection}>
             <div>RaccoonDude</div>
             <div className={classes.shutdownButton}>

--- a/src/components/Taskbar/Taskbar.tsx
+++ b/src/components/Taskbar/Taskbar.tsx
@@ -20,7 +20,13 @@ const Taskbar = ({
 }) => {
   return (
     <nav className={classes.taskbarContainer}>
-      <StartMenu numberOfOpenedApps={numberOfOpenedApps} isOpen={isStartMenuOpen} appList={appList} handleOpenApp={handleOpenApp} />
+      <StartMenu
+        numberOfOpenedApps={numberOfOpenedApps}
+        isOpen={isStartMenuOpen}
+        appList={appList}
+        handleOpenApp={handleOpenApp}
+        handleToggleStartMenu={handleToggleStartMenu}
+      />
       <TaskbarIcon
         handleClick={handleToggleStartMenu}
         isAppOpen={true}

--- a/src/components/Taskbar/Taskbar.tsx
+++ b/src/components/Taskbar/Taskbar.tsx
@@ -1,11 +1,23 @@
 import { ReactElement } from "react";
 import TaskbarIcon from "../TaskbarIcon/TaskbarIcon";
 import classes from "./Taskbar.module.css";
-const Taskbar = ({ children }: { children: ReactElement[] | ReactElement }) => {
+import StartMenu from "../StartMenu/StartMenu";
+const Taskbar = ({
+  numberOfOpenedApps,
+  isStartMenuOpen,
+  handleToggleStartMenu,
+  children,
+}: {
+  numberOfOpenedApps: number;
+  isStartMenuOpen: boolean;
+  handleToggleStartMenu: () => void;
+  children: ReactElement[] | ReactElement;
+}) => {
   return (
     <nav className={classes.taskbarContainer}>
+      <StartMenu numberOfOpenedApps={numberOfOpenedApps} isOpen={isStartMenuOpen} />
       <TaskbarIcon
-        handleClick={() => {}}
+        handleClick={handleToggleStartMenu}
         isAppOpen={true}
         isAppHidden={false}
         iconUrl="./taskbar-icons/misfitos-logo.png"

--- a/src/components/Taskbar/Taskbar.tsx
+++ b/src/components/Taskbar/Taskbar.tsx
@@ -2,20 +2,25 @@ import { ReactElement } from "react";
 import TaskbarIcon from "../TaskbarIcon/TaskbarIcon";
 import classes from "./Taskbar.module.css";
 import StartMenu from "../StartMenu/StartMenu";
+import { App } from "../Desktop/Desktop";
 const Taskbar = ({
+  appList,
   numberOfOpenedApps,
   isStartMenuOpen,
   handleToggleStartMenu,
+  handleOpenApp,
   children,
 }: {
+  appList: App[];
   numberOfOpenedApps: number;
   isStartMenuOpen: boolean;
   handleToggleStartMenu: () => void;
+  handleOpenApp: (appName: string) => void;
   children: ReactElement[] | ReactElement;
 }) => {
   return (
     <nav className={classes.taskbarContainer}>
-      <StartMenu numberOfOpenedApps={numberOfOpenedApps} isOpen={isStartMenuOpen} />
+      <StartMenu numberOfOpenedApps={numberOfOpenedApps} isOpen={isStartMenuOpen} appList={appList} handleOpenApp={handleOpenApp} />
       <TaskbarIcon
         handleClick={handleToggleStartMenu}
         isAppOpen={true}


### PR DESCRIPTION
Added a start menu to the website.

![image](https://github.com/MiguelHigueraDev/raccoonOS/assets/133175356/d6f69e4c-c9e2-4a20-a982-b7c7ff983ef3)

When opening an app or clicking outside of the start menu the start menu is closed.
For now the power button doesn't do anything.