### PR TITLE
feat: notification system + double click hint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,34 @@
-import { Analytics } from "@vercel/analytics/react";
-import "./App.css";
-import Background from "./components/Background/Background";
-import Desktop from "./components/Desktop/Desktop";
-import { useEffect } from "react";
-import { printConsoleEasterEggs } from "./helpers/consoleEasterEgg";
+import { Analytics } from '@vercel/analytics/react';
+import './App.css';
+import Background from './components/Background/Background';
+import Desktop from './components/Desktop/Desktop';
+import { useEffect } from 'react';
+import { printConsoleEasterEggs } from './helpers/consoleEasterEgg';
+import NotificationsContainer from './components/Notifications/NotificationsContainer';
+import NotificationStore from './stores/NotificationStore';
 
 function App() {
+  const { addNotification } = NotificationStore();
 
   useEffect(() => {
     printConsoleEasterEggs();
   }, []);
+
+  // Show hint notification on first load
+  useEffect(() => {
+    addNotification(
+      'welcome-notification',
+      'Welcome to RaccoonOS!',
+      'Double click apps to open them or use the start menu.'
+    );
+  }, [addNotification]);
 
   return (
     <>
       <Analytics />
       <Background />
       <Desktop />
+      <NotificationsContainer />
     </>
   );
 }

--- a/src/components/Notifications/Notification.module.css
+++ b/src/components/Notifications/Notification.module.css
@@ -1,0 +1,24 @@
+.notification {
+    background-color: white;
+    padding: 6px;
+    border-left: 3px solid rgb(239, 72, 239);
+    max-width: 250px;
+}
+
+.notification div {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.notification h2 {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    font-weight: 600;
+    margin: 0;
+}
+
+.notification p {
+    font-size: 0.9rem;
+    margin: 0;
+}

--- a/src/components/Notifications/Notification.tsx
+++ b/src/components/Notifications/Notification.tsx
@@ -1,0 +1,24 @@
+import { IconX } from '@tabler/icons-react';
+import classes from './Notification.module.css';
+
+const Notification = ({
+  title,
+  message,
+  handleRemoveNotification,
+}: {
+  title: string;
+  message: string;
+  handleRemoveNotification: () => void;
+}) => {
+  return (
+    <li className={classes.notification}>
+      <div>
+        <h2>{title}</h2>
+        <button onClick={handleRemoveNotification}><IconX size={16} /></button>
+      </div>
+      <p>{message}</p>
+    </li>
+  );
+};
+
+export default Notification;

--- a/src/components/Notifications/NotificationsContainer.module.css
+++ b/src/components/Notifications/NotificationsContainer.module.css
@@ -1,0 +1,12 @@
+.notificationsContainer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    z-index: 9999999;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    padding: 20px;
+    list-style-type: none;
+    gap: 14px;
+}

--- a/src/components/Notifications/NotificationsContainer.tsx
+++ b/src/components/Notifications/NotificationsContainer.tsx
@@ -1,0 +1,26 @@
+import NotificationStore from '../../stores/NotificationStore';
+import Notification from './Notification';
+import classes from './NotificationsContainer.module.css';
+
+const NotificationsContainer = () => {
+  const { notifications, removeNotification } = NotificationStore();
+
+  const handleRemoveNotification = (id: string) => {
+    removeNotification(id);
+  }
+
+  return (
+    <div className={classes.notificationsContainer}>
+      {notifications.map((notification) => (
+        <Notification
+          key={notification.id}
+          message={notification.message}
+          title={notification.title}
+          handleRemoveNotification={() => handleRemoveNotification(notification.id)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default NotificationsContainer;

--- a/src/stores/NotificationStore.ts
+++ b/src/stores/NotificationStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+type Store = {
+  notifications: Notification[];
+  addNotification: (id: string, title: string, message: string) => void;
+  removeNotification: (id: string) => void;
+};
+
+interface Notification {
+  id: string;
+  title: string;
+  message: string;
+}
+
+// This store manages notifications that are displayed in the top right corner of the screen
+export default create<Store>((set) => ({
+  notifications: [],
+  addNotification: (id: string, title: string, message: string) =>
+    set((state) => ({
+      notifications: [...state.notifications, { id, title, message }],
+    })),
+  removeNotification: (id: string) =>
+    set((state) => ({
+      notifications: state.notifications.filter(
+        (notification) => notification.id !== id
+      ),
+    })),
+}));


### PR DESCRIPTION
Added a notification system and also a hint on page load to let users know that apps are opened by double clicking (or by using the Start Menu).

![image](https://github.com/MiguelHigueraDev/raccoonOS/assets/133175356/58a2abae-5275-4375-9783-a0675b621aa9)
