### PR TITLE
feat: improve notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,19 @@ function App() {
     addNotification(
       'welcome-notification',
       'Welcome to RaccoonOS!',
-      'Double click apps to open them or use the start menu.'
+      <p>
+        <strong>Double click</strong> apps to open them or use the
+        <img
+          style={{
+            width: 20,
+            display: 'inline',
+            margin: '0 6px',
+            cursor: 'default',
+          }}
+          src="./raccoonos-logo.webp"
+        />
+        <strong>start menu</strong> below.
+      </p>
     );
   }, [addNotification]);
 

--- a/src/components/Notifications/Notification.tsx
+++ b/src/components/Notifications/Notification.tsx
@@ -1,5 +1,6 @@
 import { IconX } from '@tabler/icons-react';
 import classes from './Notification.module.css';
+import { ReactNode } from 'react';
 
 const Notification = ({
   title,
@@ -7,7 +8,7 @@ const Notification = ({
   handleRemoveNotification,
 }: {
   title: string;
-  message: string;
+  message: ReactNode;
   handleRemoveNotification: () => void;
 }) => {
   return (

--- a/src/stores/NotificationStore.ts
+++ b/src/stores/NotificationStore.ts
@@ -1,21 +1,22 @@
+import { ReactNode } from 'react';
 import { create } from 'zustand';
 
 type Store = {
   notifications: Notification[];
-  addNotification: (id: string, title: string, message: string) => void;
+  addNotification: (id: string, title: string, message: ReactNode) => void;
   removeNotification: (id: string) => void;
 };
 
 interface Notification {
   id: string;
   title: string;
-  message: string;
+  message: ReactNode;
 }
 
 // This store manages notifications that are displayed in the top right corner of the screen
 export default create<Store>((set) => ({
   notifications: [],
-  addNotification: (id: string, title: string, message: string) =>
+  addNotification: (id: string, title: string, message: ReactNode) =>
     set((state) => ({
       notifications: [...state.notifications, { id, title, message }],
     })),


### PR DESCRIPTION
Replaced notifications' message string type for ReactNode to allow for custom HTML.

Improved welcome notification as a result:

![image](https://github.com/MiguelHigueraDev/raccoonOS/assets/133175356/e7c75622-1350-4122-880b-a801a7eaed7a)
